### PR TITLE
allow multiple devices by using article+serial in config entry unique_id

### DIFF
--- a/custom_components/askoheat/config_flow.py
+++ b/custom_components/askoheat/config_flow.py
@@ -245,7 +245,14 @@ class AskoheatFlowHandler(ConfigFlow, domain=DOMAIN):
                     .replace("-", "_")
                     .replace(".", "_")
                 )
-                unique_id = f"{DOMAIN}_{cleaned_serial_number}"
+                cleaned_article_number = (
+                    device_infos.article_number.lower()
+                    .replace("-", "_")
+                    .replace(".", "_")
+                )
+                # Use a composite unique id based on article number and serial number
+                # to support multiple devices that may report the same serial number.
+                unique_id = f"{DOMAIN}_{cleaned_article_number}_{cleaned_serial_number}"
                 self._title = title = (
                     f"{device_infos.article_name} {device_infos.article_number} {device_infos.serial_number}"  # noqa: E501
                 )


### PR DESCRIPTION
Fixes: https://github.com/toggm/askoheat/issues/62

Problem
- Adding a second Askoheat+ device failed with abort reason already_configured when devices share the same serial number but are different models.

Change
- Use a composite unique_id in config flow: {domain}_{article_number}_{serial_number}.
- This differentiates devices by model + serial, allowing multiple hubs.

Impact
- Users can add multiple Askoheat+ devices with similar serials.
- No breaking changes for existing entries; titles and entity ids remain stable.

Testing
- Manual: add two devices with distinct article numbers; both entries are created and platforms load successfully.